### PR TITLE
Restore packages at the beginning of the build

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -46,6 +46,8 @@ Target "Clean" (fun _ ->
     CleanDir binDir
 )
 
+Target "Restore" RestorePackages
+
 //--------------------------------------------------------------------------------
 // Generate AssemblyInfo files with the version for release notes 
 
@@ -234,7 +236,7 @@ Target "PublishNuget" <| fun _ ->
 Target "All" DoNothing
 
 // build dependencies
-"Clean" ==> "AssemblyInfo" ==> "Build" ==> "CopyOutput" ==> "BuildRelease"
+"Clean" ==> "Restore" ==> "AssemblyInfo" ==> "Build" ==> "CopyOutput" ==> "BuildRelease"
 
 // nuget dependencies
 "CleanNuget" ==> "BuildRelease" ==> "Nuget"


### PR DESCRIPTION
if you clone the repo the build won't work.

This restores all NuGet packages at the beginning.